### PR TITLE
fix(core): replace fcntl with portalocker for cross-platform locking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "jup - Agent Skills Manager"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "portalocker>=2.10.0",
     "prompt-toolkit>=3.0.51",
     "pydantic>=2.10.6",
     "pygments>=2.19.2",

--- a/src/jup/core/lock.py
+++ b/src/jup/core/lock.py
@@ -1,6 +1,8 @@
-import fcntl
 import contextlib
 from pathlib import Path
+
+import portalocker
+
 from .filesystem import rel_home
 
 
@@ -13,7 +15,8 @@ class LockFileManager:
     def lock(self, write: bool = True):
         """
         Context manager for file locking.
-        Uses fcntl for Unix-based systems.
+        Uses portalocker so the same advisory-locking semantics work on both
+        POSIX (fcntl backend) and Windows (msvcrt backend).
         """
         self.lock_file_path.parent.mkdir(parents=True, exist_ok=True)
         # We need a separate file for the lock to avoid issues with reading/writing the actual JSON
@@ -22,11 +25,11 @@ class LockFileManager:
         mode = "w" if write else "r"
         try:
             with open(lock_path, mode) as f:
-                lock_type = fcntl.LOCK_EX if write else fcntl.LOCK_SH
+                lock_type = portalocker.LOCK_EX if write else portalocker.LOCK_SH
                 try:
-                    fcntl.flock(f.fileno(), lock_type)
+                    portalocker.lock(f, lock_type)
                     yield f
                 finally:
-                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
-        except IOError as e:
+                    portalocker.unlock(f)
+        except (OSError, portalocker.exceptions.LockException) as e:
             raise RuntimeError(f"Could not acquire lock on {rel_home(lock_path)}: {e}")

--- a/uv.lock
+++ b/uv.lock
@@ -328,9 +328,10 @@ wheels = [
 
 [[package]]
 name = "jup"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
+    { name = "portalocker" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pygments" },
@@ -353,6 +354,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "portalocker", specifier = ">=2.10.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pygments", specifier = ">=2.19.2" },
@@ -604,6 +606,18 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -815,6 +829,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/ae/3ac172d9cb71dcf25be15c727ce84b3b16f31df98e8015a0a73fe3e29e1c/python_semantic_release-9.21.1.tar.gz", hash = "sha256:b5c509a573899e88e8f29504d2f83e9ddab9a66af861ec1baf39f2b86bbf3517", size = 308463, upload-time = "2025-05-05T04:29:12.818Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/af/b7c6e77142586c4809cb93b636f62cecda73fa543ec4bd00a89eb3e1d4f3/python_semantic_release-9.21.1-py3-none-any.whl", hash = "sha256:e69afe5100106390eec9e800132c947ed774bdcf9aa8f0df29589ea9ef375a21", size = 132726, upload-time = "2025-05-05T04:29:10.698Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`src/jup/core/lock.py` imports `fcntl` at module top, which is POSIX-only. On Windows this raises `ModuleNotFoundError: No module named 'fcntl'` at import time, before any jup command can run:

```
$ uv tool install jup && jup --version
Traceback (most recent call last):
  ...
  File ".../jup/core/lock.py", line 1, in <module>
    import fcntl
ModuleNotFoundError: No module named 'fcntl'
```

This blocks every Windows user — including users on multi-OS teams who'd want to share a skills repo across machines.

## Fix

Replace `fcntl` with [`portalocker`](https://github.com/wolph/portalocker), a small dependency that exposes the same advisory-locking primitives (`LOCK_EX`, `LOCK_SH`, `LOCK_UN`) on top of `fcntl` on POSIX and `msvcrt` on Windows. The semantics are preserved; the public API of `LockFileManager` is unchanged.

Diff is minimal — 15 lines in `lock.py`, one new dependency in `pyproject.toml`.

## Verification

On Windows 10 + Python 3.14:

```
$ uv run pytest tests/concurrency/ tests/unit/
================== 35 passed in 2.09s ==================
```

The concurrency test (`tests/concurrency/test_locking.py::test_lock_file_exclusive`) verifies that exclusive locks actually block — it passes unchanged with the new backend. Lint (`ruff check` + `ruff format`) and typecheck (`ty check`) clean on the changed file.

## Scope

This PR is intentionally narrow: it unblocks **startup** on Windows. During testing I observed ~15 additional integration/e2e test failures on Windows that are out of scope here:

- Some tests call `os.symlink(...)` directly, which fails on Windows without Developer Mode or admin (`WinError 1314`)
- A few path assertions assume POSIX separators

Those deserve their own PRs — happy to follow up if you'd like.

## Related

While digging into the repo I also noticed there's no `LICENSE` file (`gh repo view andrader/jup --json licenseInfo` returns null). That's a separate concern but worth flagging — happy to open a follow-up PR adding one (e.g. MIT) once you've decided which license you'd like.